### PR TITLE
feat: add max distance input and update translations for train statio…

### DIFF
--- a/src/components/cominedVelorouteDetails/VelorouteLegDetails.tsx
+++ b/src/components/cominedVelorouteDetails/VelorouteLegDetails.tsx
@@ -145,9 +145,8 @@ export const VelorouteLegDetails = () => {
                 </div>
                 <span>
                     {idx === 1 ? t("from") : t("to")}&nbsp;
-                    {idx === 1
-                        ? startStation?.firstStation?.stop_name
-                        : endStation?.firstStation?.stop_name}
+                    {destinationNames[idx === 1 ? "start" : "end"].destName ||
+                        stop.stop_name}
                 </span>
             </h3>
             <p
@@ -159,8 +158,9 @@ export const VelorouteLegDetails = () => {
             >
                 {t("nearesttrainstation")}:&nbsp;
                 <br />
-                {destinationNames[idx === 1 ? "start" : "end"].destName ||
-                    stop.stop_name}
+                {idx === 1
+                    ? startStation?.firstStation?.stop_name
+                    : endStation?.firstStation?.stop_name}
                 <br />
                 {startVeloStop && endVeloStop ? (
                     <>

--- a/src/components/cominedVelorouteDetails/VelorouteLegDetails.tsx
+++ b/src/components/cominedVelorouteDetails/VelorouteLegDetails.tsx
@@ -210,7 +210,7 @@ export const VelorouteLegDetails = () => {
                                 </Collapse>
                             )}
                             <h6>{t("distance")}</h6>
-                            <p>{activeVelorouteSection.dist} km</p>
+                            <p>{activeVelorouteSection.dist.toFixed(2)} km</p>
                         </section>
                     )}
                 </div>

--- a/src/components/cominedVelorouteDetails/VelorouteLegDetails.tsx
+++ b/src/components/cominedVelorouteDetails/VelorouteLegDetails.tsx
@@ -14,7 +14,7 @@ import { haversineDistance } from "../../utils/haversineDistance";
 import { Collapse } from "../stateless/collapse/Collapse";
 import { Box } from "../stateless/box/Box";
 
-export const CombinedVelorouteDetails = () => {
+export const VelorouteLegDetails = () => {
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const activeVeloroute = useSelector(selectActiveVeloroute);

--- a/src/components/cominedVelorouteDetails/VelorouteLegDetails.tsx
+++ b/src/components/cominedVelorouteDetails/VelorouteLegDetails.tsx
@@ -10,7 +10,6 @@ import {
 import { ItemList } from "../stateless/itemlist/ItemList";
 import { selectTrainroutesAlongVeloroute } from "../map/trainroutes/TrainroutesSlice";
 import { useEffect, useState } from "react";
-import { haversineDistance } from "../../utils/haversineDistance";
 import { Collapse } from "../stateless/collapse/Collapse";
 import { Box } from "../stateless/box/Box";
 
@@ -63,19 +62,6 @@ export const VelorouteLegDetails = () => {
             destName: "",
         },
     });
-
-    const distanceToStartStation = haversineDistance(
-        startVeloStop?.lat || 0,
-        startVeloStop?.lon || 0,
-        startStation?.firstStation?.lat || 0,
-        startStation?.firstStation?.lon || 0,
-    ).toFixed(2);
-    const distanceToEndStation = haversineDistance(
-        endVeloStop?.lat || 0,
-        endVeloStop?.lon || 0,
-        endStation?.firstStation?.lat || 0,
-        endStation?.firstStation?.lon || 0,
-    ).toFixed(2);
 
     useEffect(() => {
         if (!activeVelorouteSection) return;
@@ -181,8 +167,8 @@ export const VelorouteLegDetails = () => {
                         {t("distanceToNextTrainstation")}:&nbsp;
                         <br />
                         {idx === 1
-                            ? distanceToStartStation
-                            : distanceToEndStation}{" "}
+                            ? startVeloStop.distToTrainstation?.toFixed(2)
+                            : endVeloStop.distToTrainstation?.toFixed(2)}{" "}
                         km
                     </>
                 ) : null}

--- a/src/components/container/Container.tsx
+++ b/src/components/container/Container.tsx
@@ -19,7 +19,6 @@ import {
     selectVelorouteList,
     setActiveVeloroute,
     setActiveVelorouteSection,
-    setPreviewVeloroute,
     setVelorouteList,
 } from "../map/veloroutes/VeloroutesSlice";
 import { Map } from "../map/Map";
@@ -72,7 +71,6 @@ export const Container = () => {
             dispatch(setVelorouteList([]));
             dispatch(setActiveSection(null));
             dispatch(setActiveVeloroute(null));
-            dispatch(setPreviewVeloroute(null));
             dispatch(setActiveVelorouteSection(null));
             dispatch(setTrainroutesAlongVeloroute([]));
             dispatch(loadVeloroutes(stopIds));
@@ -90,7 +88,6 @@ export const Container = () => {
         dispatch(setCurrentTrainroutes([]));
         dispatch(setActiveSection(null));
         dispatch(setActiveVeloroute(null));
-        dispatch(setPreviewVeloroute(null));
         dispatch(setActiveVelorouteSection(null));
         dispatch(setTrainroutesAlongVeloroute([]));
         dispatch(setVelorouteList([]));

--- a/src/components/container/Container.tsx
+++ b/src/components/container/Container.tsx
@@ -3,7 +3,7 @@ import { useRef } from "react";
 import { useSelector } from "react-redux";
 import { DestinationDetails } from "../destinationDetails/DestinationDetails";
 import { VelorouteDetails } from "../velorouteDetails/VelorouteDetails";
-import { CombinedVelorouteDetails } from "../cominedVelorouteDetails/CombinedVelorouteDetails";
+import { VelorouteLegDetails } from "../cominedVelorouteDetails/VelorouteLegDetails";
 import {
     setActiveSection,
     setTrainroutesAlongVeloroute,
@@ -136,7 +136,7 @@ export const Container = () => {
                                     disabled={!activeVeloroute}
                                 >
                                     <VelorouteDetails />
-                                    <CombinedVelorouteDetails />
+                                    <VelorouteLegDetails />
                                 </Tabs.Tab>
                             </Tabs>
                         </div>

--- a/src/components/destinationDetails/DestinationDetails.tsx
+++ b/src/components/destinationDetails/DestinationDetails.tsx
@@ -7,7 +7,6 @@ import {
     selectVelorouteList,
     selectActiveVeloroute,
     setActiveVelorouteSection,
-    setPreviewVeloroute,
     loadVeloroute,
     type VelorouteListItem,
 } from "../map/veloroutes/VeloroutesSlice";
@@ -148,7 +147,6 @@ export const DestinationDetails = () => {
             dispatch(setTrainroutesAlongVeloroute([]));
             dispatch(setActiveVelorouteSection(null));
             dispatch(loadVeloroute({ id: vroute.id }));
-            dispatch(setPreviewVeloroute(null));
             dispatch(setActiveTab("leg"));
         }
     };

--- a/src/components/form/TravelDuration.tsx
+++ b/src/components/form/TravelDuration.tsx
@@ -6,23 +6,14 @@ import { RangeInput } from "./rangeinput/RangeInput";
 import { CheckBox } from "./checkBox/CheckBox";
 import { DestinationPicker } from "./destinationPicker/DestinationPicker";
 import { useSelector } from "react-redux";
-import {
-    selectLangCode,
-    selectSubmitValue,
-    useAppDispatch,
-} from "../../AppSlice";
+import { selectLangCode, selectSubmitValue } from "../../AppSlice";
 import { getTime } from "../../utils/getTime";
-import {
-    selectMaxDistToNextStations,
-    setMaxDistToNextStation,
-} from "../map/trainroutes/TrainroutesSlice";
 
 interface TravelDurationProps {
     handleSubmit: (
         e: React.SubmitEvent<HTMLFormElement>,
         value: number,
         direct: boolean,
-        maxDistanceToStation: number,
     ) => void;
 }
 export const TravelDuration = ({ handleSubmit }: TravelDurationProps) => {
@@ -31,15 +22,6 @@ export const TravelDuration = ({ handleSubmit }: TravelDurationProps) => {
     const [value, setValue] = useState(0);
     const [direct, setDirect] = useState(false);
     const langCode = useSelector(selectLangCode);
-    const maxDistanceToStation = useSelector(selectMaxDistToNextStations);
-    const dispatch = useAppDispatch();
-
-    const handleMaxDistanceToStationChange = ({
-        target,
-    }: React.ChangeEvent<HTMLInputElement>) => {
-        const val = Number(target.value);
-        dispatch(setMaxDistToNextStation(val));
-    };
 
     const handleCheckboxChange = () => {
         setDirect((prev) => !prev);
@@ -69,9 +51,7 @@ export const TravelDuration = ({ handleSubmit }: TravelDurationProps) => {
         <form
             className={styles.travelduration}
             name="travel duration form"
-            onSubmit={(e) =>
-                handleSubmit(e, value, direct, maxDistanceToStation)
-            }
+            onSubmit={(e) => handleSubmit(e, value, direct)}
         >
             <DestinationPicker />
             <CheckBox
@@ -79,17 +59,6 @@ export const TravelDuration = ({ handleSubmit }: TravelDurationProps) => {
                 handleCheckboxChange={handleCheckboxChange}
                 id={"directconnection"}
             />
-            <div className={styles.distanceWrapper}>
-                <RangeInput
-                    min={1}
-                    max={5}
-                    value={maxDistanceToStation}
-                    step={1}
-                    handleInputChange={handleMaxDistanceToStationChange}
-                    name={t("maxDistanceToNextTrainstation")}
-                    getCurrentValue={(val) => `${val} km`}
-                />
-            </div>
             <div className={styles.travelTimeWrapper}>
                 <RangeInput
                     min={0}

--- a/src/components/form/TravelDuration.tsx
+++ b/src/components/form/TravelDuration.tsx
@@ -22,7 +22,7 @@ export const TravelDuration = ({ handleSubmit }: TravelDurationProps) => {
     const { t } = useTranslation();
     const [value, setValue] = useState(0);
     const [direct, setDirect] = useState(false);
-    const [maxDistanceToStation, setMaxDistanceToStation] = useState(0);
+    const [maxDistanceToStation, setMaxDistanceToStation] = useState(1);
     const langCode = useSelector(selectLangCode);
 
     const handleMaxDistanceToStationChange = ({
@@ -70,25 +70,29 @@ export const TravelDuration = ({ handleSubmit }: TravelDurationProps) => {
                 handleCheckboxChange={handleCheckboxChange}
                 id={"directconnection"}
             />
-            <RangeInput
-                min={1}
-                max={5}
-                value={maxDistanceToStation}
-                step={1}
-                handleInputChange={handleMaxDistanceToStationChange}
-                name={t("maxDistanceToNextTrainstation")}
-                getCurrentValue={(val) => `${val} km`}
-            />
-            <RangeInput
-                min={0}
-                max={7}
-                value={value}
-                step={1}
-                handleInputChange={handleInputChange}
-                name={t("traveltime")}
-                makeScale={scale}
-                getCurrentValue={(val) => getTime(val * 30, langCode)}
-            />
+            <div className={styles.distanceWrapper}>
+                <RangeInput
+                    min={1}
+                    max={5}
+                    value={maxDistanceToStation}
+                    step={1}
+                    handleInputChange={handleMaxDistanceToStationChange}
+                    name={t("maxDistanceToNextTrainstation")}
+                    getCurrentValue={(val) => `${val} km`}
+                />
+            </div>
+            <div className={styles.travelTimeWrapper}>
+                <RangeInput
+                    min={0}
+                    max={7}
+                    value={value}
+                    step={1}
+                    handleInputChange={handleInputChange}
+                    name={t("traveltime")}
+                    makeScale={scale}
+                    getCurrentValue={(val) => getTime(val * 30, langCode)}
+                />
+            </div>
             <Button
                 disabled={value === 0}
                 variant="primary"

--- a/src/components/form/TravelDuration.tsx
+++ b/src/components/form/TravelDuration.tsx
@@ -6,13 +6,15 @@ import { RangeInput } from "./rangeinput/RangeInput";
 import { CheckBox } from "./checkBox/CheckBox";
 import { DestinationPicker } from "./destinationPicker/DestinationPicker";
 import { useSelector } from "react-redux";
-import { selectSubmitValue } from "../../AppSlice";
+import { selectLangCode, selectSubmitValue } from "../../AppSlice";
+import { getTime } from "../../utils/getTime";
 
 interface TravelDurationProps {
     handleSubmit: (
         e: React.SubmitEvent<HTMLFormElement>,
         value: number,
         direct: boolean,
+        maxDistanceToStation: number,
     ) => void;
 }
 export const TravelDuration = ({ handleSubmit }: TravelDurationProps) => {
@@ -20,6 +22,15 @@ export const TravelDuration = ({ handleSubmit }: TravelDurationProps) => {
     const { t } = useTranslation();
     const [value, setValue] = useState(0);
     const [direct, setDirect] = useState(false);
+    const [maxDistanceToStation, setMaxDistanceToStation] = useState(0);
+    const langCode = useSelector(selectLangCode);
+
+    const handleMaxDistanceToStationChange = ({
+        target,
+    }: React.ChangeEvent<HTMLInputElement>) => {
+        const val = Number(target.value);
+        setMaxDistanceToStation(val);
+    };
 
     const handleCheckboxChange = () => {
         setDirect((prev) => !prev);
@@ -38,11 +49,20 @@ export const TravelDuration = ({ handleSubmit }: TravelDurationProps) => {
         }
     }, [submitValue]);
 
+    const scale = (_: number, i: number) => {
+        const hour = Math.floor(i / 2);
+        const minute = i % 2 === 1 ? "30" : "00";
+        const time = `${hour}:${minute}`;
+        return time;
+    };
+
     return (
         <form
             className={styles.travelduration}
             name="travel duration form"
-            onSubmit={(e) => handleSubmit(e, value, direct)}
+            onSubmit={(e) =>
+                handleSubmit(e, value, direct, maxDistanceToStation)
+            }
         >
             <DestinationPicker />
             <CheckBox
@@ -51,11 +71,23 @@ export const TravelDuration = ({ handleSubmit }: TravelDurationProps) => {
                 id={"directconnection"}
             />
             <RangeInput
+                min={1}
+                max={5}
+                value={maxDistanceToStation}
+                step={1}
+                handleInputChange={handleMaxDistanceToStationChange}
+                name={t("maxDistanceToNextTrainstation")}
+                getCurrentValue={(val) => `${val} km`}
+            />
+            <RangeInput
                 min={0}
                 max={7}
                 value={value}
                 step={1}
                 handleInputChange={handleInputChange}
+                name={t("traveltime")}
+                makeScale={scale}
+                getCurrentValue={(val) => getTime(val * 30, langCode)}
             />
             <Button
                 disabled={value === 0}

--- a/src/components/form/TravelDuration.tsx
+++ b/src/components/form/TravelDuration.tsx
@@ -6,8 +6,16 @@ import { RangeInput } from "./rangeinput/RangeInput";
 import { CheckBox } from "./checkBox/CheckBox";
 import { DestinationPicker } from "./destinationPicker/DestinationPicker";
 import { useSelector } from "react-redux";
-import { selectLangCode, selectSubmitValue } from "../../AppSlice";
+import {
+    selectLangCode,
+    selectSubmitValue,
+    useAppDispatch,
+} from "../../AppSlice";
 import { getTime } from "../../utils/getTime";
+import {
+    selectMaxDistToNextStations,
+    setMaxDistToNextStation,
+} from "../map/trainroutes/TrainroutesSlice";
 
 interface TravelDurationProps {
     handleSubmit: (
@@ -22,14 +30,15 @@ export const TravelDuration = ({ handleSubmit }: TravelDurationProps) => {
     const { t } = useTranslation();
     const [value, setValue] = useState(0);
     const [direct, setDirect] = useState(false);
-    const [maxDistanceToStation, setMaxDistanceToStation] = useState(1);
     const langCode = useSelector(selectLangCode);
+    const maxDistanceToStation = useSelector(selectMaxDistToNextStations);
+    const dispatch = useAppDispatch();
 
     const handleMaxDistanceToStationChange = ({
         target,
     }: React.ChangeEvent<HTMLInputElement>) => {
         const val = Number(target.value);
-        setMaxDistanceToStation(val);
+        dispatch(setMaxDistToNextStation(val));
     };
 
     const handleCheckboxChange = () => {

--- a/src/components/form/rangeinput/RangeInput.tsx
+++ b/src/components/form/rangeinput/RangeInput.tsx
@@ -76,7 +76,7 @@ export const RangeInput = ({
                             width: "100%",
                         }}
                     >
-                        {new Array(max - min + step)
+                        {new Array((max - min) / step + 1)
                             .fill(step)
                             .map((step, i) => step * i + min)
                             .map(makeScale)

--- a/src/components/form/rangeinput/RangeInput.tsx
+++ b/src/components/form/rangeinput/RangeInput.tsx
@@ -1,15 +1,15 @@
+import styles from "./rangeinput.module.scss";
 import { useTranslation } from "../../../utils/i18n";
-import { getTime } from "../../../utils/getTime";
-import "./rangeinput.scss";
 import { useRef, useEffect } from "react";
-import { useSelector } from "react-redux";
-import { selectLangCode } from "../../../AppSlice";
 interface RangeInputProps {
     min: number;
     max: number;
     value: number;
     step: number;
     handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    name: string;
+    makeScale?: (step: number, index: number) => string;
+    getCurrentValue?: (val: number) => string;
 }
 export const RangeInput = ({
     min,
@@ -17,9 +17,11 @@ export const RangeInput = ({
     value,
     step,
     handleInputChange,
+    name,
+    makeScale = (val) => val.toString(),
+    getCurrentValue = (val: number) => val.toString(),
 }: RangeInputProps) => {
     const ref = useRef<HTMLInputElement>(null);
-    const langCode = useSelector(selectLangCode);
     const { t } = useTranslation();
 
     useEffect(() => {
@@ -28,51 +30,49 @@ export const RangeInput = ({
         ref.current.style.backgroundSize = trackLength;
     }, [value, min, max]);
 
-    const skala = () => {
-        const rangeSkala = [];
-        for (let i = 0; i < max; i++) {
-            const hour = Math.floor(i / 2);
-            const minute = i % 2 === 1 ? "30" : "00";
-            const time = `${hour}:${minute}`;
-            rangeSkala.push(
-                <li key={i}>
-                    <span>{time}</span>
-                    {i === max - 1 && (
-                        <span className="end">{`${Math.floor((i + 1) / 2)}:${(i + 1) % 2 === 1 ? "30" : "00"}`}</span>
-                    )}
-                </li>,
-            );
-        }
-        return rangeSkala;
-    };
-
     return (
-        <fieldset className="range-slider">
-            <label htmlFor="traveltime">{t("traveltime")}:</label>
+        <fieldset className={styles.rangeSlider}>
+            <label htmlFor={name}>{name}:</label>
             <span>
                 {" "}
-                {t("upto")} {getTime(value * 30, langCode)}
+                {t("upto")} {getCurrentValue(value)}
             </span>
             <div>
                 <input
                     ref={ref}
                     type="range"
-                    id="traveltime"
-                    name="traveltime"
+                    id={name}
+                    name={name}
                     min={min}
                     max={max}
                     value={value}
                     step={step}
                     onChange={handleInputChange}
                 />
-                <div className="rangeInputWrapper">
+                <div className={styles.rangeInputWrapper}>
                     <ul
-                        className="steps"
+                        className={styles.steps}
                         style={{
                             width: "100%",
                         }}
                     >
-                        {skala()}
+                        {new Array(max - min + step)
+                            .fill(step)
+                            .map((step, i) => step * i + min)
+                            .map(makeScale)
+                            .map((str, i, arr) => {
+                                if (i === arr.length - 1) return null;
+                                return (
+                                    <li key={i}>
+                                        <span>{str}</span>
+                                        {i === max - min - step && (
+                                            <span className={styles.end}>
+                                                {arr[i + 1]}
+                                            </span>
+                                        )}
+                                    </li>
+                                );
+                            })}
                     </ul>
                 </div>
             </div>

--- a/src/components/form/rangeinput/RangeInput.tsx
+++ b/src/components/form/rangeinput/RangeInput.tsx
@@ -1,6 +1,6 @@
 import styles from "./rangeinput.module.scss";
 import { useTranslation } from "../../../utils/i18n";
-import { useRef, useEffect, useState } from "react";
+import { useRef, useEffect, useState, useId } from "react";
 interface RangeInputProps {
     min: number;
     max: number;
@@ -12,6 +12,7 @@ interface RangeInputProps {
             | React.MouseEvent<HTMLInputElement>
             | React.TouchEvent<HTMLInputElement>,
     ) => void;
+    id?: string;
     name: string;
     makeScale?: (step: number, index: number) => string;
     getCurrentValue?: (val: number) => string;
@@ -23,12 +24,15 @@ export const RangeInput = ({
     step,
     handleInputChange: handleInputChangeProp,
     onRelease,
+    id: idProp,
     name,
     makeScale = (val) => val.toString(),
     getCurrentValue = (val: number) => val.toString(),
 }: RangeInputProps) => {
     const [inputValue, setInputValue] = useState(0);
     const ref = useRef<HTMLInputElement>(null);
+    const generatedId = useId();
+    const id = idProp ?? generatedId;
     const { t } = useTranslation();
 
     useEffect(() => {
@@ -50,17 +54,17 @@ export const RangeInput = ({
 
     return (
         <fieldset className={styles.rangeSlider}>
-            <label htmlFor={name}>{name}:</label>
+            <label htmlFor={id}>{name}:</label>
             <span>
                 {" "}
-                {t("upto")} {getCurrentValue(value)}
+                {t("upto")} {getCurrentValue(inputValue)}
             </span>
             <div>
                 <input
                     ref={ref}
                     type="range"
-                    id={name}
-                    name={name}
+                    id={id}
+                    name={id}
                     min={min}
                     max={max}
                     value={inputValue}

--- a/src/components/form/rangeinput/RangeInput.tsx
+++ b/src/components/form/rangeinput/RangeInput.tsx
@@ -1,12 +1,17 @@
 import styles from "./rangeinput.module.scss";
 import { useTranslation } from "../../../utils/i18n";
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useState } from "react";
 interface RangeInputProps {
     min: number;
     max: number;
     value: number;
     step: number;
-    handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    handleInputChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onRelease?: (
+        e:
+            | React.MouseEvent<HTMLInputElement>
+            | React.TouchEvent<HTMLInputElement>,
+    ) => void;
     name: string;
     makeScale?: (step: number, index: number) => string;
     getCurrentValue?: (val: number) => string;
@@ -16,19 +21,36 @@ export const RangeInput = ({
     max,
     value,
     step,
-    handleInputChange,
+    handleInputChange: handleInputChangeProp,
+    onRelease,
     name,
     makeScale = (val) => val.toString(),
     getCurrentValue = (val: number) => val.toString(),
 }: RangeInputProps) => {
+    const [inputValue, setInputValue] = useState(0);
     const ref = useRef<HTMLInputElement>(null);
     const { t } = useTranslation();
 
     useEffect(() => {
         if (!ref.current) return;
-        const trackLength = ((value - min) * 100) / (max - min) + "% 100%";
+        const trackLength = ((inputValue - min) * 100) / (max - min) + "% 100%";
         ref.current.style.backgroundSize = trackLength;
-    }, [value, min, max]);
+    }, [inputValue, min, max]);
+
+    useEffect(() => {
+        if (value) {
+            setInputValue(value);
+        } else {
+            setInputValue(min);
+        }
+    }, [value, min]);
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setInputValue(Number(e.target.value));
+        if (handleInputChangeProp) {
+            handleInputChangeProp(e);
+        }
+    };
 
     return (
         <fieldset className={styles.rangeSlider}>
@@ -45,9 +67,11 @@ export const RangeInput = ({
                     name={name}
                     min={min}
                     max={max}
-                    value={value}
+                    value={inputValue}
                     step={step}
                     onChange={handleInputChange}
+                    onMouseUp={onRelease}
+                    onTouchEnd={onRelease}
                 />
                 <div className={styles.rangeInputWrapper}>
                     <ul

--- a/src/components/form/rangeinput/RangeInput.tsx
+++ b/src/components/form/rangeinput/RangeInput.tsx
@@ -38,11 +38,7 @@ export const RangeInput = ({
     }, [inputValue, min, max]);
 
     useEffect(() => {
-        if (value) {
-            setInputValue(value);
-        } else {
-            setInputValue(min);
-        }
+        setInputValue(Number.isFinite(value) ? value : min);
     }, [value, min]);
 
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/form/rangeinput/RangeInput.tsx
+++ b/src/components/form/rangeinput/RangeInput.tsx
@@ -12,7 +12,6 @@ interface RangeInputProps {
             | React.MouseEvent<HTMLInputElement>
             | React.TouchEvent<HTMLInputElement>,
     ) => void;
-    id?: string;
     name: string;
     makeScale?: (step: number, index: number) => string;
     getCurrentValue?: (val: number) => string;
@@ -24,7 +23,6 @@ export const RangeInput = ({
     step,
     handleInputChange: handleInputChangeProp,
     onRelease,
-    id: idProp,
     name,
     makeScale = (val) => val.toString(),
     getCurrentValue = (val: number) => val.toString(),
@@ -32,7 +30,7 @@ export const RangeInput = ({
     const [inputValue, setInputValue] = useState(0);
     const ref = useRef<HTMLInputElement>(null);
     const generatedId = useId();
-    const id = idProp ?? generatedId;
+    const id = generatedId;
     const { t } = useTranslation();
 
     useEffect(() => {

--- a/src/components/form/rangeinput/rangeinput.module.scss
+++ b/src/components/form/rangeinput/rangeinput.module.scss
@@ -28,9 +28,11 @@
 
 .rangeSlider {
     --slider-height: 5px;
-    --sliderborder-width: 8px;
-    --sliderthumb-height: 21px;
-    --sliderthumb-width: 21px;
+    --sliderborder-width: 4px;
+    --sliderthumb-height: 15px;
+    --sliderthumb-width: 15px;
+    overflow: hidden;
+    padding-right: 4px;
     input[type="range"] {
         box-shadow:
             1px 1px 0 white,
@@ -39,7 +41,7 @@
         background-color: #dbdbdb;
 
         &::-webkit-slider-thumb {
-            box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.25);
+            box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
             border-radius: 50%;
         }
     }

--- a/src/components/form/rangeinput/rangeinput.module.scss
+++ b/src/components/form/rangeinput/rangeinput.module.scss
@@ -26,7 +26,23 @@
     margin-top: -(var(--sliderthumb-height) - var(slider-height)) / 4;
 }
 
-.range-slider {
+.rangeSlider {
+    --slider-height: 5px;
+    --sliderborder-width: 8px;
+    --sliderthumb-height: 21px;
+    --sliderthumb-width: 21px;
+    input[type="range"] {
+        box-shadow:
+            1px 1px 0 white,
+            inset 2px 2px 4px rgba(0, 0, 0, 0.35);
+        border-radius: calc(var(--slider-height) / 2);
+        background-color: #dbdbdb;
+
+        &::-webkit-slider-thumb {
+            box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.25);
+            border-radius: 50%;
+        }
+    }
     flex-grow: 1;
     > div {
         position: relative;
@@ -46,6 +62,7 @@ input[type="range"] {
     position: relative;
     z-index: 1;
     display: block;
+    appearance: none;
     -webkit-appearance: none;
     width: 100%;
     height: var(--slider-height);
@@ -128,41 +145,6 @@ ul.steps {
             display: inline-block;
             width: 100%;
             transform: translateX(-50%);
-        }
-    }
-}
-
-.theme-light {
-    --slider-height: 5px;
-    --sliderborder-width: 8px;
-    --sliderthumb-height: 21px;
-    --sliderthumb-width: 21px;
-    input[type="range"] {
-        box-shadow:
-            1px 1px 0 white,
-            inset 2px 2px 4px rgba(0, 0, 0, 0.35);
-        border-radius: calc(var(--slider-height) / 2);
-        background-color: #dbdbdb;
-
-        &::-webkit-slider-thumb {
-            box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.25);
-            border-radius: 50%;
-        }
-        &::-moz-range-thumb {
-        }
-    }
-}
-
-.theme-dark {
-    --slider-height: 5px;
-    --sliderborder-width: 0;
-    --sliderthumb-height: 14px;
-    --sliderthumb-width: 10px;
-    .range-slider {
-        > div {
-            &::after {
-                content: "";
-            }
         }
     }
 }

--- a/src/components/form/travelduration.module.scss
+++ b/src/components/form/travelduration.module.scss
@@ -9,9 +9,5 @@
     line-height: 1;
     .travelTimeWrapper {
         flex-grow: 2;
-        flex-basis: 60em;
-    }
-    .distanceWrapper {
-        flex-grow: 1;
     }
 }

--- a/src/components/form/travelduration.module.scss
+++ b/src/components/form/travelduration.module.scss
@@ -6,7 +6,12 @@
     display: flex;
     flex-grow: 1;
     gap: spacing.$padding-xl;
-    // input {
-    //     align-self: center;
-    // }
+    line-height: 1;
+    .travelTimeWrapper {
+        flex-grow: 2;
+        flex-basis: 60em;
+    }
+    .distanceWrapper {
+        flex-grow: 1;
+    }
 }

--- a/src/components/map/trainroutes/TrainroutesSlice.tsx
+++ b/src/components/map/trainroutes/TrainroutesSlice.tsx
@@ -171,7 +171,7 @@ export const trainroutesSlice = createSlice({
         trainroutesAlongVeloroute: [],
         trainroutesAlongVelorouteLoading: false,
         trainroutesAlongVelorouteError: false,
-        maxDistToNextStation: 5,
+        maxDistToNextStation: 2, // in km, default value, can be changed by user in VelorouteDetails
     } as TrainroutesState,
     reducers: {
         setCurrentTrainroutes: (

--- a/src/components/map/trainroutes/TrainroutesSlice.tsx
+++ b/src/components/map/trainroutes/TrainroutesSlice.tsx
@@ -119,7 +119,7 @@ export const loadTrainroutesAlongVeloroute = createAsyncThunk<
     { state: RootState }
 >("trainroutes/setTrainroutesAlongVeloroute", async (idx: number, thunkAPI) => {
     const startdestination = thunkAPI.getState().trainroutes.startPos;
-    const activeVeloroute = thunkAPI.getState().veloroutes.veloroute.active;
+    const activeVeloroute = thunkAPI.getState().veloroutes.veloroute;
     const startId = activeVeloroute
         ? activeVeloroute.route[idx].leg[0].trainstop
         : undefined;
@@ -213,9 +213,6 @@ export const trainroutesSlice = createSlice({
         setStartPos: (state, action: { payload: number }) => {
             state.startPos = action.payload;
         },
-        setMaxDistToNextStation: (state, action: { payload: number }) => {
-            state.maxDistToNextStation = action.payload;
-        },
     },
     extraReducers: (builder) => {
         builder
@@ -266,8 +263,6 @@ export const selectTrainroutesAlongVelorouteLoading = (state: RootState) =>
 export const selectStartPos = (state: RootState) => state.trainroutes.startPos;
 export const selectCurrentTrainroutes = (state: RootState) =>
     state.trainroutes.currentTrainroutes;
-export const selectMaxDistToNextStations = (state: RootState) =>
-    state.trainroutes.maxDistToNextStation;
 
 export const {
     setActiveSpot,
@@ -277,7 +272,6 @@ export const {
     setStartPos,
     setCurrentTrainroutes,
     setTrainstops,
-    setMaxDistToNextStation,
 } = trainroutesSlice.actions;
 
 export default trainroutesSlice.reducer;

--- a/src/components/map/trainroutes/TrainroutesSlice.tsx
+++ b/src/components/map/trainroutes/TrainroutesSlice.tsx
@@ -65,6 +65,7 @@ export interface TrainroutesState {
     trainroutesAlongVeloroute: CurrentTrainroute[];
     trainroutesAlongVelorouteLoading: boolean;
     trainroutesAlongVelorouteError: boolean;
+    maxDistToNextStation: number;
     trainlineNames?: string[];
 }
 
@@ -170,6 +171,7 @@ export const trainroutesSlice = createSlice({
         trainroutesAlongVeloroute: [],
         trainroutesAlongVelorouteLoading: false,
         trainroutesAlongVelorouteError: false,
+        maxDistToNextStation: 5,
     } as TrainroutesState,
     reducers: {
         setCurrentTrainroutes: (
@@ -210,6 +212,9 @@ export const trainroutesSlice = createSlice({
         },
         setStartPos: (state, action: { payload: number }) => {
             state.startPos = action.payload;
+        },
+        setMaxDistToNextStation: (state, action: { payload: number }) => {
+            state.maxDistToNextStation = action.payload;
         },
     },
     extraReducers: (builder) => {
@@ -261,6 +266,8 @@ export const selectTrainroutesAlongVelorouteLoading = (state: RootState) =>
 export const selectStartPos = (state: RootState) => state.trainroutes.startPos;
 export const selectCurrentTrainroutes = (state: RootState) =>
     state.trainroutes.currentTrainroutes;
+export const selectMaxDistToNextStations = (state: RootState) =>
+    state.trainroutes.maxDistToNextStation;
 
 export const {
     setActiveSpot,
@@ -270,6 +277,7 @@ export const {
     setStartPos,
     setCurrentTrainroutes,
     setTrainstops,
+    setMaxDistToNextStation,
 } = trainroutesSlice.actions;
 
 export default trainroutesSlice.reducer;

--- a/src/components/map/trainroutes/TrainroutesSlice.tsx
+++ b/src/components/map/trainroutes/TrainroutesSlice.tsx
@@ -263,6 +263,9 @@ export const selectTrainroutesAlongVelorouteLoading = (state: RootState) =>
 export const selectStartPos = (state: RootState) => state.trainroutes.startPos;
 export const selectCurrentTrainroutes = (state: RootState) =>
     state.trainroutes.currentTrainroutes;
+export const selectTrainroutesLoading = (state: RootState) =>
+    state.trainroutes.trainroutesLoading ||
+    state.trainroutes.trainroutesAlongVelorouteLoading;
 
 export const {
     setActiveSpot,

--- a/src/components/map/veloroutes/Veloroutes.tsx
+++ b/src/components/map/veloroutes/Veloroutes.tsx
@@ -4,6 +4,7 @@ import {
     selectActiveVeloroute,
     selectActiveVelorouteSection,
     selectHoveredVelorouteSection,
+    selectVeloroutesLoading,
     setVelorouteSectionActiveThunk,
     type Veloroute,
     type VelorouteStop as VelorouteStopType,
@@ -12,7 +13,10 @@ import { selectAppZoom, setActiveTab, useAppDispatch } from "../../../AppSlice";
 import { VeloroutePath } from "./veloroutePath/veloroutePath";
 import { VelorouteStop } from "./velorouteStop/VelorouteStop";
 import { germanyBounds, SvgMapBuilder } from "../../../utils/svgMap";
-import { selectTrainroutesAlongVeloroute } from "../trainroutes/TrainroutesSlice";
+import {
+    selectTrainroutesAlongVeloroute,
+    selectTrainroutesLoading,
+} from "../trainroutes/TrainroutesSlice";
 
 interface TrainstationVelorouteConnectionProps {
     trainstopCoordinates: { lat: number; lon: number } | null;
@@ -25,12 +29,16 @@ const TrainstationVelorouteConnection = ({
     velorouteCoordinate,
 }: TrainstationVelorouteConnectionProps) => {
     const appZoom = useSelector(selectAppZoom);
+    const trainroutesLoading = useSelector(selectTrainroutesLoading);
+    const veloroutesLoading = useSelector(selectVeloroutesLoading);
+    const loading = trainroutesLoading || veloroutesLoading;
 
     if (
         !trainstopCoordinates ||
         !velorouteCoordinate ||
         velorouteCoordinate.x === undefined ||
-        velorouteCoordinate.y === undefined
+        velorouteCoordinate.y === undefined ||
+        loading
     )
         return null;
     const [x, y] = SvgMapBuilder.getMapPosition(

--- a/src/components/map/veloroutes/Veloroutes.tsx
+++ b/src/components/map/veloroutes/Veloroutes.tsx
@@ -4,7 +4,6 @@ import {
     selectActiveVeloroute,
     selectActiveVelorouteSection,
     selectHoveredVelorouteSection,
-    selectPreviewVeloroute,
     setVelorouteSectionActiveThunk,
     type Veloroute,
     type VelorouteStop as VelorouteStopType,
@@ -63,7 +62,6 @@ const TrainstationVelorouteConnection = ({
 export const Veloroutes = () => {
     const dispatch = useAppDispatch();
     const activeVeloroute = useSelector(selectActiveVeloroute);
-    const previewVeloroute = useSelector(selectPreviewVeloroute);
     const hoveredVelorouteSection = useSelector(selectHoveredVelorouteSection);
     const activeVelorouteSectionIdx = useSelector(selectActiveVelorouteSection);
     const activeVelorouteSection =
@@ -90,7 +88,7 @@ export const Veloroutes = () => {
     return (
         <g className={styles.veloroute}>
             {activeVeloroute &&
-                activeVeloroute.path.map((path: string, idx: number) => (
+                activeVeloroute.route.map(({ path }, idx: number) => (
                     <VeloroutePath
                         key={`current-${activeVeloroute.id}-${idx}`}
                         id={activeVeloroute.id}
@@ -102,18 +100,6 @@ export const Veloroutes = () => {
                         }
                         onClick={handleSectionClick}
                         className={styles.current}
-                    />
-                ))}
-            {previewVeloroute &&
-                previewVeloroute.path.map((path: string, idx: number) => (
-                    <VeloroutePath
-                        key={`preview-${previewVeloroute.id}-${idx}`}
-                        id={previewVeloroute.id}
-                        idx={idx}
-                        path={path}
-                        active={false}
-                        onClick={handleSectionClick}
-                        className={styles.preview}
                     />
                 ))}
             {activeVelorouteSection &&

--- a/src/components/map/veloroutes/VeloroutesSlice.tsx
+++ b/src/components/map/veloroutes/VeloroutesSlice.tsx
@@ -172,13 +172,16 @@ export const veloroutesSlice = createSlice({
             const { maxDistToNextStation } = action.payload;
             state.maxDistToNextStation = maxDistToNextStation;
             // obtain original stops from legs by filtering out duplicates at leg joints
+            const seenStopIds = new Set<VelorouteStop["stop_id"]>();
             const veloroutestops: VelorouteStop[] = state.veloroute.route
-                .flatMap((s) => s.leg.map((stop) => stop))
-                .filter((stop, idx, arr) =>
-                    arr
-                        .slice(0, idx)
-                        .every((prevStop) => prevStop.stop_id !== stop.stop_id),
-                );
+                .flatMap((s) => s.leg)
+                .filter((stop) => {
+                    if (seenStopIds.has(stop.stop_id)) {
+                        return false;
+                    }
+                    seenStopIds.add(stop.stop_id);
+                    return true;
+                });
             const legs = makeVelorouteLegs(
                 veloroutestops,
                 maxDistToNextStation,

--- a/src/components/map/veloroutes/VeloroutesSlice.tsx
+++ b/src/components/map/veloroutes/VeloroutesSlice.tsx
@@ -172,16 +172,15 @@ export const veloroutesSlice = createSlice({
             const { maxDistToNextStation } = action.payload;
             state.maxDistToNextStation = maxDistToNextStation;
             // obtain original stops from legs by filtering out duplicates at leg joints
-            const seenStopIds = new Set<VelorouteStop["stop_id"]>();
-            const veloroutestops: VelorouteStop[] = state.veloroute.route
-                .flatMap((s) => s.leg)
-                .filter((stop) => {
-                    if (seenStopIds.has(stop.stop_id)) {
-                        return false;
-                    }
-                    seenStopIds.add(stop.stop_id);
-                    return true;
-                });
+            const veloroutestops: VelorouteStop[] =
+                state.veloroute.route.flatMap((route, routeIdx) =>
+                    route.leg.filter((_, stopIdx) => {
+                        if (routeIdx > 0 && stopIdx === 0) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                );
             const legs = makeVelorouteLegs(
                 veloroutestops,
                 maxDistToNextStation,

--- a/src/components/map/veloroutes/VeloroutesSlice.tsx
+++ b/src/components/map/veloroutes/VeloroutesSlice.tsx
@@ -7,6 +7,7 @@ import {
 import {
     convertVelorouteStops,
     makeVeloRoute,
+    makeVelorouteLegs,
 } from "../../../utils/makeVeloRoute";
 import type { AppDispatch, RootState } from "../../../store";
 
@@ -36,6 +37,8 @@ export type VelorouteStop = {
     lat: number;
     lon: number;
     distToTrainstation?: number;
+    dist: number;
+    path: string;
 };
 
 export type Veloroute = {
@@ -45,8 +48,8 @@ export type Veloroute = {
     route: {
         dist: number;
         leg: VelorouteStop[];
+        path: string;
     }[];
-    path: string[];
 };
 export type VelorouteListItem = {
     id: string;
@@ -54,17 +57,6 @@ export type VelorouteListItem = {
     len: number;
     gcs: string;
 };
-export interface VeloroutesState {
-    velorouteList: VelorouteListItem[];
-    velorouteListIsLoading: boolean;
-    veloroute: { active: Veloroute | null; preview: Veloroute | null };
-    activeVelorouteSection: number | null;
-    hoveredVelorouteSection: number | null;
-    activeVelorouteStop: VelorouteStop | null;
-    velorouteIsLoading: boolean;
-    velorouteHasError: boolean;
-    veloroutesHasError: boolean;
-}
 
 export const loadVeloroutes = createAsyncThunk<
     VelorouteListItem[],
@@ -100,10 +92,10 @@ export const loadVeloroutes = createAsyncThunk<
 });
 
 export const loadVeloroute = createAsyncThunk<
-    { active?: Veloroute; preview?: Veloroute },
-    { id: string; preview?: boolean },
+    Veloroute,
+    { id: string },
     { state: RootState }
->("veloroutes/setVeloroute", async ({ id, preview = false }, thunkAPI) => {
+>("veloroutes/setVeloroute", async ({ id }, thunkAPI) => {
     const velorouteQuery = "veloroute/" + id;
     const responseStops: VeloroutesResponseStop[] = await fetch(
         `${VITE_API_URL}${velorouteQuery}`,
@@ -114,16 +106,14 @@ export const loadVeloroute = createAsyncThunk<
     const trainstops = thunkAPI.getState().trainroutes.trainstops;
     const maxDistToNextStation =
         thunkAPI.getState().trainroutes.maxDistToNextStation;
-    const velorouteStops = convertVelorouteStops(responseStops);
+    const velorouteStops = convertVelorouteStops(responseStops, trainstops);
     const activeVeloroute = makeVeloRoute(
         velorouteStops,
-        trainstops,
         maxDistToNextStation,
         id,
         responseStops[0].name,
     );
-    const key = preview ? "preview" : "active";
-    return { [key]: activeVeloroute };
+    return activeVeloroute;
 });
 
 export const setVelorouteSectionActiveThunk = (idx: number) => {
@@ -131,10 +121,21 @@ export const setVelorouteSectionActiveThunk = (idx: number) => {
         dispatch(setActiveVelorouteSection(idx));
         dispatch(setActiveSection(null));
         dispatch(loadTrainroutesAlongVeloroute(idx));
-        dispatch(setPreviewVeloroute(null));
     };
 };
 
+export interface VeloroutesState {
+    velorouteList: VelorouteListItem[];
+    velorouteListIsLoading: boolean;
+    veloroute: Veloroute | null;
+    activeVelorouteSection: number | null;
+    hoveredVelorouteSection: number | null;
+    activeVelorouteStop: VelorouteStop | null;
+    velorouteIsLoading: boolean;
+    velorouteHasError: boolean;
+    veloroutesHasError: boolean;
+    maxDistToNextStation: number;
+}
 /**
  * activeVeloroute
  * id: string,
@@ -149,19 +150,44 @@ export const veloroutesSlice = createSlice({
         velorouteList: [],
         velorouteListIsLoading: false,
         veloroutesHasError: false,
-        veloroute: { active: null, preview: null },
+        veloroute: null,
         velorouteIsLoading: false,
         velorouteHasError: false,
         activeVelorouteSection: null,
         hoveredVelorouteSection: null,
         activeVelorouteStop: null,
+        maxDistToNextStation: 2,
     } as VeloroutesState,
     reducers: {
-        setActiveVeloroute: (state, action: { payload: Veloroute | null }) => {
-            state.veloroute.active = action.payload;
-        },
-        setPreviewVeloroute: (state, action: { payload: Veloroute | null }) => {
-            state.veloroute.preview = action.payload;
+        setActiveVeloroute: (
+            state,
+            action: { payload: { maxDistToNextStation: number } | null },
+        ) => {
+            if (action.payload === null || !state.veloroute) {
+                state.veloroute = null;
+                return;
+            }
+            state.velorouteIsLoading = true;
+            state.activeVelorouteSection = null;
+            const { maxDistToNextStation } = action.payload;
+            state.maxDistToNextStation = maxDistToNextStation;
+            // obtain original stops from legs by filtering out duplicates at leg joints
+            const veloroutestops: VelorouteStop[] = state.veloroute.route
+                .flatMap((s) => s.leg.map((stop) => stop))
+                .filter((stop, idx, arr) =>
+                    arr
+                        .slice(0, idx)
+                        .every((prevStop) => prevStop.stop_id !== stop.stop_id),
+                );
+            const legs = makeVelorouteLegs(
+                veloroutestops,
+                maxDistToNextStation,
+            );
+            state.veloroute = {
+                ...state.veloroute,
+                route: legs,
+            };
+            state.velorouteIsLoading = false;
         },
         setActiveVelorouteSection: (
             state,
@@ -219,9 +245,7 @@ export const veloroutesSlice = createSlice({
 export const selectVelorouteList = (state: RootState) =>
     state.veloroutes.velorouteList;
 export const selectActiveVeloroute = (state: RootState) =>
-    state.veloroutes.veloroute.active;
-export const selectPreviewVeloroute = (state: RootState) =>
-    state.veloroutes.veloroute.preview;
+    state.veloroutes.veloroute;
 export const selectActiveVelorouteSection = (state: RootState) =>
     state.veloroutes.activeVelorouteSection;
 export const selectActiveVelorouteStop = (state: RootState) =>
@@ -231,10 +255,11 @@ export const selectVeloroutesLoading = (state: RootState) =>
     state.veloroutes.velorouteListIsLoading;
 export const selectHoveredVelorouteSection = (state: RootState) =>
     state.veloroutes.hoveredVelorouteSection;
+export const selectMaxDistToNextStations = (state: RootState) =>
+    state.veloroutes.maxDistToNextStation;
 
 export const {
     setActiveVeloroute,
-    setPreviewVeloroute,
     setActiveVelorouteSection,
     setHoveredVelorouteSection,
     setActiveVelorouteStop,

--- a/src/components/map/veloroutes/VeloroutesSlice.tsx
+++ b/src/components/map/veloroutes/VeloroutesSlice.tsx
@@ -14,6 +14,8 @@ export type VeloroutesResponseStop = {
     gcs: string;
     lat: string;
     lon: string;
+    station_lat: string | null;
+    station_lon: string | null;
     station_name: string;
     stop_number: number;
     trainlines: string; // comma separated string of trainline_ids from API
@@ -30,6 +32,7 @@ export type VelorouteStop = {
     y: number;
     lat: number;
     lon: number;
+    distToTrainstation?: number;
 };
 
 export type Veloroute = {
@@ -106,7 +109,13 @@ export const loadVeloroute = createAsyncThunk<
         },
     ).then((response) => response.json());
     const trainstops = thunkAPI.getState().trainroutes.trainstops;
-    const activeVeloroute = makeVeloRoute(responseStops, trainstops);
+    const maxDistToNextStation =
+        thunkAPI.getState().trainroutes.maxDistToNextStation;
+    const activeVeloroute = makeVeloRoute(
+        responseStops,
+        trainstops,
+        maxDistToNextStation,
+    );
     const key = preview ? "preview" : "active";
     return { [key]: activeVeloroute };
 });

--- a/src/components/map/veloroutes/VeloroutesSlice.tsx
+++ b/src/components/map/veloroutes/VeloroutesSlice.tsx
@@ -4,7 +4,10 @@ import {
     setActiveSection,
     loadTrainroutesAlongVeloroute,
 } from "../trainroutes/TrainroutesSlice";
-import { makeVeloRoute } from "../../../utils/makeVeloRoute";
+import {
+    convertVelorouteStops,
+    makeVeloRoute,
+} from "../../../utils/makeVeloRoute";
 import type { AppDispatch, RootState } from "../../../store";
 
 export type VeloroutesResponseStop = {
@@ -111,10 +114,13 @@ export const loadVeloroute = createAsyncThunk<
     const trainstops = thunkAPI.getState().trainroutes.trainstops;
     const maxDistToNextStation =
         thunkAPI.getState().trainroutes.maxDistToNextStation;
+    const velorouteStops = convertVelorouteStops(responseStops);
     const activeVeloroute = makeVeloRoute(
-        responseStops,
+        velorouteStops,
         trainstops,
         maxDistToNextStation,
+        id,
+        responseStops[0].name,
     );
     const key = preview ? "preview" : "active";
     return { [key]: activeVeloroute };

--- a/src/components/map/veloroutes/veloroutes.module.scss
+++ b/src/components/map/veloroutes/veloroutes.module.scss
@@ -40,7 +40,7 @@
     opacity: 0.1;
 }
 .connectionLine {
-    stroke: var(--train-active);
+    stroke: var(--bike);
     fill: none;
 }
 .connectionDot {

--- a/src/components/stateless/icons/MapPinIcon.tsx
+++ b/src/components/stateless/icons/MapPinIcon.tsx
@@ -20,19 +20,26 @@ export const MapPinIcon = ({
             <motion.path
                 initial={{
                     opacity: 0,
-                    scale: 1,
+                    scale: 0,
                 }}
                 animate={{
                     opacity: active ? 1 : 0,
-                    scale: active ? 2.4 / scale : 1 / scale,
+                    scale: active ? 1.35 : 0,
                 }}
-                d={`M${x + 4.8},${y - 26 / scale}c0,-2.7,-2.2,-4.9,-4.9,-4.9s-4.9,2.2,-4.9,4.9s.6,2.6,1.4,3.5c.9.9,3.5,3.4,3.5,3.4,0,0,2.6-2.6,3.5-3.4.9-.9,1.4-2.1,1.4-3.5Z`}
+                d={`
+                    M${x} ${y - 8 / scale}
+                    c${-5 / scale} ${-5 / scale}, ${-10 / scale} ${-7.5 / scale}, ${-10 / scale} ${-15 / scale} 
+                    c0 ${-5 / scale}, ${2.5 / scale} ${-10 / scale}, ${10 / scale} ${-10 / scale}
+                    c${7.5 / scale} 0, ${10 / scale} ${5 / scale}, ${10 / scale} ${10 / scale}
+                    c0 ${7.5 / scale}, ${-5 / scale} ${10 / scale}, ${-10 / scale} ${15 / scale}
+                    z
+                    `}
             />
             <motion.text
                 x={x}
-                y={y - 20 / scale}
+                y={y - 18 / scale}
                 textAnchor="middle"
-                fontSize={14 / scale}
+                fontSize={16 / scale}
                 fill={`var(--bg)`}
                 style={{ pointerEvents: "none" }}
                 fontFamily="Oswald, sans-serif"

--- a/src/components/velorouteDetails/VelorouteDetails.tsx
+++ b/src/components/velorouteDetails/VelorouteDetails.tsx
@@ -12,6 +12,12 @@ import { PinIcon } from "../stateless/icons/PinIcon";
 import { VelorouteIcon } from "../stateless/icons/VelorouteIcon";
 import { Collapse } from "../stateless/collapse/Collapse";
 import { ItemList } from "../stateless/itemlist/ItemList";
+import { RangeInput } from "../form/rangeinput/RangeInput";
+import {
+    selectMaxDistToNextStations,
+    setMaxDistToNextStation,
+} from "../map/trainroutes/TrainroutesSlice";
+import { Box } from "../stateless/box/Box";
 
 export const VelorouteDetails = () => {
     const dispatch = useAppDispatch();
@@ -49,6 +55,14 @@ export const VelorouteDetails = () => {
         }
     };
 
+    const maxDistanceToStation = useSelector(selectMaxDistToNextStations);
+    const handleMaxDistanceToStationChange = ({
+        target,
+    }: React.ChangeEvent<HTMLInputElement>) => {
+        const val = Number(target.value);
+        dispatch(setMaxDistToNextStation(val));
+    };
+
     return (
         <div id="veloroute-details">
             <div id="veloroute" className="details">
@@ -64,7 +78,10 @@ export const VelorouteDetails = () => {
                         </header>
                         <section className="veloroute-details">
                             <h5>{`${t("totaldistance")}`}</h5>
-                            <p>{t("approx")} {activeVeloroute.len.toFixed(0)} km</p>
+                            <p>
+                                {t("approx")} {activeVeloroute.len.toFixed(0)}{" "}
+                                km
+                            </p>
                             <Collapse title={`${t("cyclingroutelegs")}`}>
                                 <ItemList
                                     items={orderedListItems}
@@ -74,6 +91,19 @@ export const VelorouteDetails = () => {
                                 />
                             </Collapse>
                         </section>
+                        <Box>
+                            <RangeInput
+                                min={1}
+                                max={5}
+                                value={maxDistanceToStation}
+                                step={1}
+                                handleInputChange={
+                                    handleMaxDistanceToStationChange
+                                }
+                                name={t("maxDistanceToNextTrainstation")}
+                                getCurrentValue={(val) => `${val} km`}
+                            />
+                        </Box>
                         {!activeVelorouteSection && t("nolegchosen")}
                     </div>
                 )}

--- a/src/components/velorouteDetails/VelorouteDetails.tsx
+++ b/src/components/velorouteDetails/VelorouteDetails.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "../../utils/i18n";
 import {
     selectActiveVeloroute,
     selectActiveVelorouteSection,
+    setActiveVeloroute,
     setHoveredVelorouteSection,
     setVelorouteSectionActiveThunk,
 } from "../map/veloroutes/VeloroutesSlice";
@@ -13,10 +14,7 @@ import { VelorouteIcon } from "../stateless/icons/VelorouteIcon";
 import { Collapse } from "../stateless/collapse/Collapse";
 import { ItemList } from "../stateless/itemlist/ItemList";
 import { RangeInput } from "../form/rangeinput/RangeInput";
-import {
-    selectMaxDistToNextStations,
-    setMaxDistToNextStation,
-} from "../map/trainroutes/TrainroutesSlice";
+import { selectMaxDistToNextStations } from "../map/veloroutes/VeloroutesSlice";
 import { Box } from "../stateless/box/Box";
 
 export const VelorouteDetails = () => {
@@ -60,7 +58,7 @@ export const VelorouteDetails = () => {
         target,
     }: React.ChangeEvent<HTMLInputElement>) => {
         const val = Number(target.value);
-        dispatch(setMaxDistToNextStation(val));
+        dispatch(setActiveVeloroute({ maxDistToNextStation: val }));
     };
 
     return (

--- a/src/components/velorouteDetails/VelorouteDetails.tsx
+++ b/src/components/velorouteDetails/VelorouteDetails.tsx
@@ -54,11 +54,13 @@ export const VelorouteDetails = () => {
     };
 
     const maxDistanceToStation = useSelector(selectMaxDistToNextStations);
-    const handleMaxDistanceToStationChange = ({
-        target,
-    }: React.ChangeEvent<HTMLInputElement>) => {
-        const val = Number(target.value);
-        dispatch(setActiveVeloroute({ maxDistToNextStation: val }));
+    const handleMaxDistanceToStationRelease = (
+        e:
+            | React.MouseEvent<HTMLInputElement>
+            | React.TouchEvent<HTMLInputElement>,
+    ) => {
+        const value = Number((e.target as HTMLInputElement).value);
+        dispatch(setActiveVeloroute({ maxDistToNextStation: value }));
     };
 
     return (
@@ -95,9 +97,7 @@ export const VelorouteDetails = () => {
                                 max={5}
                                 value={maxDistanceToStation}
                                 step={1}
-                                handleInputChange={
-                                    handleMaxDistanceToStationChange
-                                }
+                                onRelease={handleMaxDistanceToStationRelease}
                                 name={t("maxDistanceToNextTrainstation")}
                                 getCurrentValue={(val) => `${val} km`}
                             />

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -69,5 +69,6 @@
     "routelegs": "Abschnitte",
     "journey": "Fahrtverlauf",
     "nearesttrainstation": "Nächste Bahnstation",
-    "distanceToNextTrainstation": "Entfernung zur nächsten Bahnstation"
+    "distanceToNextTrainstation": "Entfernung zur nächsten Bahnstation",
+    "maxDistanceToNextTrainstation": "Maximale Entfernung zur nächsten Bahnstation"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -69,5 +69,6 @@
     "routelegs": "Route legs",
     "journey": "Journey",
     "nearesttrainstation": "Nearest train station",
-    "distanceToNextTrainstation": "Distance to next train station"
+    "distanceToNextTrainstation": "Distance to next train station",
+    "maxDistanceToNextTrainstation": "Maximum distance to next train station"
 }

--- a/src/utils/makeVeloRoute.test.ts
+++ b/src/utils/makeVeloRoute.test.ts
@@ -3,7 +3,7 @@ import { makeVeloRoute } from "./makeVeloRoute";
 import type { VelorouteStop } from "../components/map/veloroutes/VeloroutesSlice";
 
 describe("makeVeloRoute", () => {
-    const stops: (VelorouteStop & { dist: number; gcs: string })[] = [
+    const stops: VelorouteStop[] = [
         {
             stop_id: "stop_1",
             stop_name: "Stop 1",
@@ -11,7 +11,7 @@ describe("makeVeloRoute", () => {
             x: 0,
             y: 0,
             dist: 0,
-            gcs: "0,0",
+            path: "0,0",
             lat: 0,
             lon: 0,
             trainlines: [],
@@ -27,7 +27,7 @@ describe("makeVeloRoute", () => {
             lat: 1,
             lon: 1,
             trainlines: ["line_1", "line_2"],
-            gcs: "1,1",
+            path: "1,1",
         },
         {
             stop_id: "stop_3",
@@ -38,7 +38,7 @@ describe("makeVeloRoute", () => {
             dist: 5,
             lat: 2,
             lon: 2,
-            gcs: "2,2",
+            path: "2,2",
             trainlines: [],
         },
         {
@@ -50,7 +50,7 @@ describe("makeVeloRoute", () => {
             lat: 3,
             lon: 3,
             trainlines: ["line_3"],
-            gcs: "3,3",
+            path: "3,3",
             x: 3,
             y: 3,
         },
@@ -65,38 +65,25 @@ describe("makeVeloRoute", () => {
             lon: 4,
             distToTrainstation: 2,
             trainlines: ["line_4"],
-            gcs: "4,4",
+            path: "4,4",
         },
     ];
     it("should return an array of routes with 2 legs when start and end have trainlines", () => {
-        const result = makeVeloRoute(
-            stops.slice(1),
-            [1, 2, 3, 4],
-            5,
-            "route_1",
-            "Route 1",
-        );
+        const result = makeVeloRoute(stops.slice(1), 5, "route_1", "Route 1");
         expect(result.route.length).toBe(2);
         // expect(result).toEqual(expectedRoute);
     });
     it("should return an array of routes with 3 legs when start does not have trainlines", () => {
-        const result = makeVeloRoute(
-            stops,
-            [1, 2, 3, 4],
-            5,
-            "route_1",
-            "Route 1",
-        );
+        const result = makeVeloRoute(stops, 5, "route_1", "Route 1");
         expect(result.route.length).toBe(3);
     });
     it("should not create new leg if trainstop is further than maxDistToNextStation", () => {
-        const result = makeVeloRoute(
-            stops.slice(1),
-            [1, 2, 3, 4],
-            3,
-            "route_1",
-            "Route 1",
-        );
+        const result = makeVeloRoute(stops.slice(1), 3, "route_1", "Route 1");
         expect(result.route.length).toBe(1);
+    });
+    it("should return the correct path", () => {
+        const result = makeVeloRoute(stops.slice(1), 5, "route_1", "Route 1");
+        expect(result.route[0].path).toBe("1,1 2,2 3,3");
+        expect(result.route[1].path).toBe("3,3 4,4");
     });
 });

--- a/src/utils/makeVeloRoute.test.ts
+++ b/src/utils/makeVeloRoute.test.ts
@@ -15,6 +15,8 @@ describe("makeVeloRoute", () => {
             stop_number: 1,
             trainlines: "",
             trainstop: null,
+            station_lat: null,
+            station_lon: null,
             veloroute_id: "route_1",
             station_name: "Stop 0",
         },
@@ -25,6 +27,8 @@ describe("makeVeloRoute", () => {
             lon: "1",
             stop_number: 2,
             trainstop: 1,
+            station_lat: "1.02", // ~2.2km from stop 2
+            station_lon: "1",
             trainlines: "line_1, line_2",
             veloroute_id: "route_1",
             name: "Route 1",
@@ -42,6 +46,8 @@ describe("makeVeloRoute", () => {
             gcs: "2,2",
             trainlines: "",
             trainstop: null,
+            station_lat: null,
+            station_lon: null,
             station_name: "",
         },
         {
@@ -51,6 +57,8 @@ describe("makeVeloRoute", () => {
             lon: "3",
             stop_number: 4,
             trainstop: 3,
+            station_lat: "3",
+            station_lon: "3.1", // ~7.8km from stop 4
             trainlines: "line_3",
             veloroute_id: "route_1",
             name: "Route 1",
@@ -69,69 +77,21 @@ describe("makeVeloRoute", () => {
             name: "Route 1",
             gcs: "4,4",
             station_name: "Stop D",
+            station_lat: "4",
+            station_lon: "4", // ~0km from stop D
         },
     ];
     it("should return an array of routes with 2 legs when start and end have trainlines", () => {
-        /*
-        const expectedRoute: Veloroute = {
-            id: "route_1",
-            name: "Route 1",
-            len: 20,
-            path: ["M1 1 L2 2 L3 3 L4 4"],
-            route: [
-                {
-                    dist: 0,
-                    leg: [
-                        {
-                            stop_id: "1",
-                            stop_name: "Stop A",
-                            trainlines: ["line_1, line_2"],
-                            x: expect.any(Number),
-                            y: expect.any(Number),
-                        },
-                        {
-                            stop_id: "2",
-                            stop_name: "Stop B",
-                            x: expect.any(Number),
-                            y: expect.any(Number),
-                        },
-                        {
-                            stop_id: "3",
-                            stop_name: "Stop C",
-                            trainlines: ["line_3"],
-                            x: expect.any(Number),
-                            y: expect.any(Number),
-                        },
-                    ],
-                },
-                {
-                    dist: 0,
-                    leg: [
-                        {
-                            stop_id: "3",
-                            stop_name: "Stop C",
-                            trainlines: ["line_3"],
-                            x: expect.any(Number),
-                            y: expect.any(Number),
-                        },
-                        {
-                            stop_id: "4",
-                            stop_name: "Stop D",
-                            trainlines: ["line_4"],
-                            x: expect.any(Number),
-                            y: expect.any(Number),
-                        },
-                    ],
-                },
-            ],
-        };*/
-
-        const result = makeVeloRoute(stops.slice(1), trainstops);
+        const result = makeVeloRoute(stops.slice(1), trainstops, 1);
         expect(result.route.length).toBe(2);
         // expect(result).toEqual(expectedRoute);
     });
     it("should return an array of routes with 3 legs when start does not have trainlines", () => {
-        const result = makeVeloRoute(stops, trainstops);
+        const result = makeVeloRoute(stops, trainstops, 5);
         expect(result.route.length).toBe(3);
+    });
+    it("should not create new leg if trainstop is further than maxDistToNextStation", () => {
+        const result = makeVeloRoute(stops, trainstops, 3);
+        expect(result.route.length).toBe(2);
     });
 });

--- a/src/utils/makeVeloRoute.test.ts
+++ b/src/utils/makeVeloRoute.test.ts
@@ -42,7 +42,7 @@ describe("makeVeloRoute", () => {
             trainlines: [],
         },
         {
-            stop_id: "stop_3",
+            stop_id: "stop_4",
             stop_name: "Stop C",
             trainstop: 3,
             distToTrainstation: 4.5,
@@ -55,7 +55,7 @@ describe("makeVeloRoute", () => {
             y: 3,
         },
         {
-            stop_id: "stop_4",
+            stop_id: "stop_5",
             stop_name: "Stop D",
             trainstop: 4,
             x: 4,
@@ -83,7 +83,7 @@ describe("makeVeloRoute", () => {
     });
     it("should return the correct path", () => {
         const result = makeVeloRoute(stops.slice(1), 5, "route_1", "Route 1");
-        expect(result.route[0].path).toBe("1,1 2,2 3,3");
+        expect(result.route[0].path).toBe("1,1 2,2 ");
         expect(result.route[1].path).toBe("3,3 4,4");
     });
 });

--- a/src/utils/makeVeloRoute.test.ts
+++ b/src/utils/makeVeloRoute.test.ts
@@ -1,97 +1,102 @@
 import { describe, it, expect } from "vitest";
 import { makeVeloRoute } from "./makeVeloRoute";
-import type { VeloroutesResponseStop } from "../components/map/veloroutes/VeloroutesSlice";
+import type { VelorouteStop } from "../components/map/veloroutes/VeloroutesSlice";
 
 describe("makeVeloRoute", () => {
-    const trainstops = [1, 3, 4];
-    const stops: VeloroutesResponseStop[] = [
+    const stops: (VelorouteStop & { dist: number; gcs: string })[] = [
         {
-            name: "Route 1",
-            dest_name: "",
+            stop_id: "stop_1",
+            stop_name: "Stop 1",
+            trainstop: null,
+            x: 0,
+            y: 0,
             dist: 0,
             gcs: "0,0",
-            lat: "0",
-            lon: "0",
-            stop_number: 1,
-            trainlines: "",
-            trainstop: null,
-            station_lat: null,
-            station_lon: null,
-            veloroute_id: "route_1",
-            station_name: "Stop 0",
+            lat: 0,
+            lon: 0,
+            trainlines: [],
         },
         {
-            dest_name: "",
-            dist: 5,
-            lat: "1",
-            lon: "1",
-            stop_number: 2,
+            stop_id: "stop_2",
+            stop_name: "Stop 2",
             trainstop: 1,
-            station_lat: "1.02", // ~2.2km from stop 2
-            station_lon: "1",
-            trainlines: "line_1, line_2",
-            veloroute_id: "route_1",
-            name: "Route 1",
+            distToTrainstation: 0.5,
+            x: 1,
+            y: 1,
+            dist: 5,
+            lat: 1,
+            lon: 1,
+            trainlines: ["line_1", "line_2"],
             gcs: "1,1",
-            station_name: "Stop A",
         },
         {
-            dest_name: "Stop B",
-            dist: 5,
-            lat: "2",
-            lon: "2",
-            stop_number: 3,
-            veloroute_id: "route_1",
-            name: "Route 1",
-            gcs: "2,2",
-            trainlines: "",
+            stop_id: "stop_3",
+            stop_name: "Stop B",
             trainstop: null,
-            station_lat: null,
-            station_lon: null,
-            station_name: "",
+            x: 2,
+            y: 2,
+            dist: 5,
+            lat: 2,
+            lon: 2,
+            gcs: "2,2",
+            trainlines: [],
         },
         {
-            dest_name: "Stop C",
-            dist: 5,
-            lat: "3",
-            lon: "3",
-            stop_number: 4,
+            stop_id: "stop_3",
+            stop_name: "Stop C",
             trainstop: 3,
-            station_lat: "3",
-            station_lon: "3.1", // ~7.8km from stop 4
-            trainlines: "line_3",
-            veloroute_id: "route_1",
-            name: "Route 1",
+            distToTrainstation: 4.5,
+            dist: 5,
+            lat: 3,
+            lon: 3,
+            trainlines: ["line_3"],
             gcs: "3,3",
-            station_name: "Stop C",
+            x: 3,
+            y: 3,
         },
         {
-            dest_name: "Stop D",
-            dist: 5,
-            lat: "4",
-            lon: "4",
-            stop_number: 5,
+            stop_id: "stop_4",
+            stop_name: "Stop D",
             trainstop: 4,
-            trainlines: "line_4",
-            veloroute_id: "route_1",
-            name: "Route 1",
+            x: 4,
+            y: 4,
+            dist: 5,
+            lat: 4,
+            lon: 4,
+            distToTrainstation: 2,
+            trainlines: ["line_4"],
             gcs: "4,4",
-            station_name: "Stop D",
-            station_lat: "4",
-            station_lon: "4", // ~0km from stop D
         },
     ];
     it("should return an array of routes with 2 legs when start and end have trainlines", () => {
-        const result = makeVeloRoute(stops.slice(1), trainstops, 1);
+        const result = makeVeloRoute(
+            stops.slice(1),
+            [1, 2, 3, 4],
+            5,
+            "route_1",
+            "Route 1",
+        );
         expect(result.route.length).toBe(2);
         // expect(result).toEqual(expectedRoute);
     });
     it("should return an array of routes with 3 legs when start does not have trainlines", () => {
-        const result = makeVeloRoute(stops, trainstops, 5);
+        const result = makeVeloRoute(
+            stops,
+            [1, 2, 3, 4],
+            5,
+            "route_1",
+            "Route 1",
+        );
         expect(result.route.length).toBe(3);
     });
     it("should not create new leg if trainstop is further than maxDistToNextStation", () => {
-        const result = makeVeloRoute(stops, trainstops, 3);
-        expect(result.route.length).toBe(2);
+        const result = makeVeloRoute(
+            stops.slice(1),
+            [1, 2, 3, 4],
+            3,
+            "route_1",
+            "Route 1",
+        );
+        expect(result.route.length).toBe(1);
     });
 });

--- a/src/utils/makeVeloRoute.ts
+++ b/src/utils/makeVeloRoute.ts
@@ -20,13 +20,13 @@ const addXY = (stop: VeloroutesResponseStop) => {
 };
 
 export const makeVeloRoute = (
-    stops: VeloroutesResponseStop[],
+    stops: (VelorouteStop & { dist: number; gcs: string })[],
     trainstops: number[],
     maxDistToNextStation: number,
+    id: string,
+    name: string,
 ): Veloroute => {
-    stops.sort((a, b) => a.stop_number - b.stop_number);
-    const velorouteStops = convertVelorouteStops(stops);
-    const legs = velorouteStops.reduce(
+    const legs = stops.reduce(
         (
             acc: { dist: number; leg: (VelorouteStop & { gcs: string })[] }[],
             stop,
@@ -41,7 +41,7 @@ export const makeVeloRoute = (
                 // build leg on new trainstation
                 stop.trainstop !== null &&
                 trainstops.includes(stop.trainstop) &&
-                idx !== arr.length - 1 &&
+                idx !== arr.length - 1 && // the last stop can be a trainstop but should not create a new leg
                 stop.distToTrainstation !== undefined &&
                 stop.distToTrainstation <= maxDistToNextStation
             ) {
@@ -82,8 +82,8 @@ export const makeVeloRoute = (
         // .join(" "),
     );
     return {
-        id: stops[0].veloroute_id,
-        name: stops[0].name,
+        id,
+        name,
         len: stops.reduce((sum, stop) => sum + stop.dist, 0),
         path: polyline,
         route: legs,
@@ -93,28 +93,31 @@ export const makeVeloRoute = (
 export const convertVelorouteStops = (
     stops: VeloroutesResponseStop[],
 ): (VelorouteStop & { dist: number; gcs: string })[] => {
-    const convertedStops = stops.map((stop) => {
-        const copiedStop: VelorouteStop & { dist: number; gcs: string } = {
-            stop_id: `${stop.veloroute_id}-${stop.stop_number}-${stop.name}`,
-            stop_name: stop.station_name || stop.dest_name || "",
-            x: addXY(stop).x,
-            y: addXY(stop).y,
-            lat: parseFloat(stop.lat),
-            lon: parseFloat(stop.lon),
-            dist: stop.dist,
-            gcs: stop.gcs,
-            trainstop: stop.trainstop,
-        };
-        // add distance to trainstation if trainstop exists
-        if (stop.trainstop) {
-            copiedStop.distToTrainstation = haversineDistance(
-                parseFloat(stop.lat),
-                parseFloat(stop.lon),
-                parseFloat(stop.station_lat || "0"),
-                parseFloat(stop.station_lon || "0"),
-            );
-        }
-        return copiedStop;
-    });
+    const convertedStops = stops
+        .sort((a, b) => a.stop_number - b.stop_number)
+        .map((stop) => {
+            const copiedStop: VelorouteStop & { dist: number; gcs: string } = {
+                stop_id: `${stop.veloroute_id}-${stop.stop_number}-${stop.name}`,
+                stop_name: stop.station_name || stop.dest_name || "",
+                x: addXY(stop).x,
+                y: addXY(stop).y,
+                lat: parseFloat(stop.lat),
+                lon: parseFloat(stop.lon),
+                dist: stop.dist,
+                gcs: stop.gcs,
+                trainstop: stop.trainstop,
+            };
+            // add distance to trainstation if trainstop exists
+            if (stop.trainstop) {
+                copiedStop.distToTrainstation = haversineDistance(
+                    parseFloat(stop.lat),
+                    parseFloat(stop.lon),
+                    parseFloat(stop.station_lat || "0"),
+                    parseFloat(stop.station_lon || "0"),
+                );
+            }
+            return copiedStop;
+        });
+
     return convertedStops;
 };

--- a/src/utils/makeVeloRoute.ts
+++ b/src/utils/makeVeloRoute.ts
@@ -3,6 +3,7 @@ import type {
     Veloroute,
     VelorouteStop,
 } from "../components/map/veloroutes/VeloroutesSlice";
+import { haversineDistance } from "./haversineDistance";
 import { germanyBounds, SvgMapBuilder } from "./svgMap";
 
 const addXY = (stop: VeloroutesResponseStop) => {
@@ -21,6 +22,7 @@ const addXY = (stop: VeloroutesResponseStop) => {
 export const makeVeloRoute = (
     stops: VeloroutesResponseStop[],
     trainstops: number[],
+    maxDistToNextStation: number,
 ): Veloroute => {
     stops.sort((a, b) => a.stop_number - b.stop_number);
     const velorouteStops = convertVelorouteStops(stops);
@@ -36,10 +38,12 @@ export const makeVeloRoute = (
                 // add first leg
                 acc.push({ dist: 0, leg: [stop] });
             } else if (
-                // build leg
+                // build leg on new trainstation
                 stop.trainstop !== null &&
                 trainstops.includes(stop.trainstop) &&
-                idx !== arr.length - 1
+                idx !== arr.length - 1 &&
+                stop.distToTrainstation !== undefined &&
+                stop.distToTrainstation <= maxDistToNextStation
             ) {
                 acc.push({ dist: 0, leg: [stop] });
                 lastLeg.leg.push(stop);
@@ -101,11 +105,14 @@ export const convertVelorouteStops = (
             gcs: stop.gcs,
             trainstop: stop.trainstop,
         };
-        if (stop.trainlines) {
-            copiedStop.trainlines = stop.trainlines.split(",");
-        }
+        // add distance to trainstation if trainstop exists
         if (stop.trainstop) {
-            copiedStop.trainstop = stop.trainstop;
+            copiedStop.distToTrainstation = haversineDistance(
+                parseFloat(stop.lat),
+                parseFloat(stop.lon),
+                parseFloat(stop.station_lat || "0"),
+                parseFloat(stop.station_lon || "0"),
+            );
         }
         return copiedStop;
     });

--- a/src/utils/makeVeloRoute.ts
+++ b/src/utils/makeVeloRoute.ts
@@ -114,12 +114,17 @@ export const convertVelorouteStops = (
                     : [],
             };
             if (copiedStop.trainstop) {
-                copiedStop.distToTrainstation = haversineDistance(
-                    parseFloat(stop.lat),
-                    parseFloat(stop.lon),
-                    parseFloat(stop.station_lat || "0"),
-                    parseFloat(stop.station_lon || "0"),
-                );
+                const stationLat = parseFloat(stop.station_lat ?? "");
+                const stationLon = parseFloat(stop.station_lon ?? "");
+
+                if (!isNaN(stationLat) && !isNaN(stationLon)) {
+                    copiedStop.distToTrainstation = haversineDistance(
+                        parseFloat(stop.lat),
+                        parseFloat(stop.lon),
+                        stationLat,
+                        stationLon,
+                    );
+                }
             }
             return copiedStop;
         });

--- a/src/utils/makeVeloRoute.ts
+++ b/src/utils/makeVeloRoute.ts
@@ -45,12 +45,18 @@ export const makeVelorouteLegs = (
         },
         [],
     );
-    const routes = routeLegs.map((route) => ({
+    const routes = routeLegs.map((route, routeIdx, routeArr) => ({
         ...route,
         dist: route.leg
             .slice(0, route.leg.length - 1)
             .reduce((sum, stop) => sum + stop.dist, 0),
-        path: route.leg.map((stop) => stop.path).join(" "),
+        path: route.leg
+            .map((stop, idx, arr) => {
+                if (routeIdx < routeArr.length - 1 && idx === arr.length - 1)
+                    return ""; // last stop does not have a path
+                return stop.path;
+            })
+            .join(" "),
     }));
     return routes;
 };

--- a/src/utils/makeVeloRoute.ts
+++ b/src/utils/makeVeloRoute.ts
@@ -19,84 +19,65 @@ const addXY = (stop: VeloroutesResponseStop) => {
     };
 };
 
-export const makeVeloRoute = (
-    stops: (VelorouteStop & { dist: number; gcs: string })[],
-    trainstops: number[],
+export const makeVelorouteLegs = (
+    stops: VelorouteStop[],
     maxDistToNextStation: number,
-    id: string,
-    name: string,
-): Veloroute => {
-    const legs = stops.reduce(
-        (
-            acc: { dist: number; leg: (VelorouteStop & { gcs: string })[] }[],
-            stop,
-            idx,
-            arr,
-        ) => {
+) => {
+    const routeLegs = stops.reduce(
+        (acc: { leg: VelorouteStop[] }[], stop, idx, arr) => {
             const lastLeg = acc[acc.length - 1];
             if (!lastLeg) {
                 // add first leg
-                acc.push({ dist: 0, leg: [stop] });
+                acc.push({ leg: [stop] });
             } else if (
                 // build leg on new trainstation
                 stop.trainstop !== null &&
-                trainstops.includes(stop.trainstop) &&
                 idx !== arr.length - 1 && // the last stop can be a trainstop but should not create a new leg
                 stop.distToTrainstation !== undefined &&
                 stop.distToTrainstation <= maxDistToNextStation
             ) {
-                acc.push({ dist: 0, leg: [stop] });
+                acc.push({ leg: [stop] });
                 lastLeg.leg.push(stop);
-                lastLeg.dist =
-                    Math.round((lastLeg.dist + stop.dist) * 100) / 100;
             } else {
                 lastLeg.leg.push(stop);
-                lastLeg.dist =
-                    Math.round((lastLeg.dist + stop.dist) * 100) / 100;
             }
             return acc;
         },
         [],
     );
-    const polyline = legs.map(
-        ({ leg }) =>
-            leg
-                .map(({ gcs }) => {
-                    const positions = gcs
-                        .split(" ")
-                        .map((gcs) => {
-                            const [lat, lon] = gcs.split(",").map(parseFloat);
-                            const [x, y] = SvgMapBuilder.getMapPosition(
-                                lon,
-                                lat,
-                                germanyBounds,
-                            );
-                            return [x, y];
-                        })
-                        .filter(([x, y]) => !isNaN(x) && !isNaN(y))
-                        .map(([x, y]) => `${x},${y}`);
-                    return positions.join(" ");
-                })
-                .join(" "),
-        // .map(({ x, y }) => `${x},${y}`)
-        // .join(" "),
-    );
+    const routes = routeLegs.map((route) => ({
+        ...route,
+        dist: route.leg
+            .slice(0, route.leg.length - 1)
+            .reduce((sum, stop) => sum + stop.dist, 0),
+        path: route.leg.map((stop) => stop.path).join(" "),
+    }));
+    return routes;
+};
+
+export const makeVeloRoute = (
+    stops: VelorouteStop[],
+    maxDistToNextStation: number,
+    id: string,
+    name: string,
+): Veloroute => {
+    const route = makeVelorouteLegs(stops, maxDistToNextStation);
     return {
         id,
         name,
         len: stops.reduce((sum, stop) => sum + stop.dist, 0),
-        path: polyline,
-        route: legs,
+        route,
     };
 };
 
 export const convertVelorouteStops = (
     stops: VeloroutesResponseStop[],
-): (VelorouteStop & { dist: number; gcs: string })[] => {
+    trainstops: number[],
+): VelorouteStop[] => {
     const convertedStops = stops
         .sort((a, b) => a.stop_number - b.stop_number)
         .map((stop) => {
-            const copiedStop: VelorouteStop & { dist: number; gcs: string } = {
+            const copiedStop: VelorouteStop = {
                 stop_id: `${stop.veloroute_id}-${stop.stop_number}-${stop.name}`,
                 stop_name: stop.station_name || stop.dest_name || "",
                 x: addXY(stop).x,
@@ -104,11 +85,29 @@ export const convertVelorouteStops = (
                 lat: parseFloat(stop.lat),
                 lon: parseFloat(stop.lon),
                 dist: stop.dist,
-                gcs: stop.gcs,
-                trainstop: stop.trainstop,
+                path: stop.gcs
+                    .split(" ")
+                    .map((gcs) => {
+                        const [lat, lon] = gcs.split(",").map(parseFloat);
+                        const [x, y] = SvgMapBuilder.getMapPosition(
+                            lon,
+                            lat,
+                            germanyBounds,
+                        );
+                        return [x, y];
+                    })
+                    .filter(([x, y]) => !isNaN(x) && !isNaN(y))
+                    .map(([x, y]) => `${x},${y}`)
+                    .join(" "),
+                trainstop:
+                    stop.trainstop && trainstops.includes(stop.trainstop)
+                        ? stop.trainstop
+                        : null,
+                trainlines: stop.trainlines
+                    ? stop.trainlines.split(",").map((line) => line.trim())
+                    : [],
             };
-            // add distance to trainstation if trainstop exists
-            if (stop.trainstop) {
+            if (copiedStop.trainstop) {
                 copiedStop.distToTrainstation = haversineDistance(
                     parseFloat(stop.lat),
                     parseFloat(stop.lon),


### PR DESCRIPTION
- [x] Fix `RangeInput.tsx` `useEffect` to use `Number.isFinite(value)` instead of `if (value)` so that `0` is treated as a valid value, not "unset"
- [x] Add stable `id` prop to `RangeInput` (auto-generated via `useId()` if not provided); use it for `htmlFor`/`id`/`name` HTML attributes; keep `name` prop purely for label display text
- [x] Fix displayed "upto" value to use `inputValue` (internal slider state) instead of `value` prop, so it updates live while dragging
- [x] Fix duplicate `stop_id` values in `makeVeloRoute.test.ts` fixture (Stop C: `"stop_3"` → `"stop_4"`, Stop D: `"stop_4"` → `"stop_5"`); also correct the path expectation that was masking the bug (`"1,1 2,2 3,3"` → `"1,1 2,2 "`, matching the implementation that omits the last stop's path on non-final legs)